### PR TITLE
Add limit param, default to 100 artworks in the query

### DIFF
--- a/src/resolvers/queryResolvers.js
+++ b/src/resolvers/queryResolvers.js
@@ -7,42 +7,45 @@ import {
 
 const queryResolvers = {
   Query: {
-    author: async (root, data, { elasticsearch: { Artworks } }) => {
-      if (data.id) {
+    author: async (obj, args, { elasticsearch: { Artworks } }) => {
+      if (args.id) {
         return await getUniqueAuthors(Artworks).find((author) => {
-          return parseInt(author.author) === parseInt(data.id)
+          return parseInt(author.author) === parseInt(args.id)
         })
       }
     },
-    artwork: async (root, data, { elasticsearch: { Artworks } }) => {
-      if (data.id)
-        return await Artworks.find(artwork =>parseInt(artwork.id) === parseInt(data.id))
+    artwork: async (obj, args, { elasticsearch: { Artworks } }) => {
+      if (args.id) {
+        return await Artworks.find((artwork) => {
+          return parseInt(artwork.id) === parseInt(args.id)
+        })
+      }
     },
-    medium: async(root, data, { elasticsearch: { Artworks } }) => {
+    medium: async(obj, args, { elasticsearch: { Artworks } }) => {
       return await getUniqueMediums(Artworks).find((medium) => {
-        if (data.id) return parseInt(medium.id) === parseInt(data.id)
+        if (args.id) return parseInt(medium.id) === parseInt(args.id)
       })
     },
-    area: async(root, data, { elasticsearch: { Artworks } }) => {
+    area: async(obj, args, { elasticsearch: { Artworks } }) => {
       return await getUniqueAreas(Artworks).find((area) => {
-        if (data.id) return parseInt(area.id) === parseInt(data.id)
+        if (args.id) return parseInt(area.id) === parseInt(args.id)
       })
     },
-    authors: async (root, data, { elasticsearch: { Artworks } }) => {
+    authors: async (obj, args, { elasticsearch: { Artworks } }) => {
       return await getUniqueAuthors(Artworks)
     },
-    artworks: async (root, data, { elasticsearch: { Artworks } }) => {
-      if (data.area) {
+    artworks: async (obj, args, { elasticsearch: { Artworks } }) => {
+      if (args.area) {
         return await Artworks.filter((artwork) => {
           return artwork.areacategories.find((ac) => {
             return ac.areacat.find((areacat) => {
-              return areacat.text === data.area
+              return areacat.text === args.area
             })
           })
-        })
+        }).slice(0, args.limit)
       }
 
-      return await Artworks
+      return await Artworks.slice(0, args.limit)
     },
     mediums: async (root, data, { elasticsearch: { Artworks } }) => {
       return await getUniqueMediums(Artworks)

--- a/src/schema/typeDefs.js
+++ b/src/schema/typeDefs.js
@@ -99,7 +99,7 @@ const typeDefs = `
   }
 
   type Query {
-    artworks(area: String): [Artwork!]!
+    artworks(limit: Int = 100, area: String): [Artwork!]!
     authors: [Author!]!
     mediums: [Medium]
     areas(artwork: ID): [Area]


### PR DESCRIPTION
This should be harmless, allowing us to pass a limit param.

I would eventually like this to change the esQuery limit, not just use javascript `slice(0, limit)`, but not sure how to do that...

I renamed the arguments to what was in the documentation (even though I think obj is not as descriptive, it should make it easier to search and see the same terms in docs and our codebase)