### PR TITLE
Use Auth0 search_engine v3

### DIFF
--- a/src/classes/user/index.js
+++ b/src/classes/user/index.js
@@ -23,7 +23,10 @@ const getUserSync = async id => {
 
   const user = await request({
     url: `https://${auth0info.AUTH0_DOMAIN}/api/v2/users/${id}`,
-    method: 'GET',
+    qs: {
+      search_engine: 'v3'
+    },
+    method: 'GET',    
     headers: {
       'content-type': 'application/json',
       Authorization: `bearer ${auth0Token}`
@@ -67,6 +70,9 @@ const setApiToken = async id => {
 
   const user = await request({
     url: `https://${auth0info.AUTH0_DOMAIN}/api/v2/users/${id}`,
+    qs: {
+      search_engine: 'v3'
+    },
     method: 'PATCH',
     headers: {
       'content-type': 'application/json',
@@ -112,6 +118,9 @@ const setRoles = async (id, roles) => {
 
   const user = await request({
     url: `https://${auth0info.AUTH0_DOMAIN}/api/v2/users/${id}`,
+    qs: {
+      search_engine: 'v3'
+    },
     method: 'PATCH',
     headers: {
       'content-type': 'application/json',


### PR DESCRIPTION
From Auth0:

The User Search v2 engine is deprecated, please use v3 (search_engine=v3) instead. For guidance on how to upgrade from v2 to v3, see: https://auth0.com/docs/users/search/v3/migrate-search-v2-v3

To ensure that your queries are using search engine v3 prior to v2 becoming unavailable, you must update all your calls to the `GET /api/v2/users` endpoint to include the `search_engine=v3` parameter. This will enable you to see whether any queries need to be updated, so that you will not experience downtime when v2 becomes unavailable.